### PR TITLE
add origins

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,8 @@
   "content_scripts": [
     {
       "matches": [
+        "https://preview.portal.azure.com/*",
+        "https://ms.portal.azure.com/*",
         "https://portal.azure.com/*"
       ],
       "js": [


### PR DESCRIPTION
Add following origins:
  - `ms.portal.azure.com`
  - `preview.portal.azure.com`

Ref: https://github.com/horihiro/Azure-portal-plus-ChromeExtension/issues/1