### PR TITLE
add user style example to hide empty resource groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ The default decoration colors are:
 
 And you can change the style by using <a href="https://chromewebstore.google.com/search/user%20css">the User CSS extensions</a> (i.e. Stylus etc.)
 
+- Example: Hide empty resource groups  
+  https://userstyles.world/style/23821
+
 # Try this
 
 ### From Chrome Web Store


### PR DESCRIPTION
This pull request adds a helpful example to the documentation to guide users on customizing the appearance of empty resource groups using user CSS extensions.

Documentation update:

* Added a link to a user style example for hiding empty resource groups in the `README.md` to assist users in customizing styles with browser extensions.