### PR TITLE
Bump to 1.1.2

### DIFF
--- a/content/js/cloudshell/main.js
+++ b/content/js/cloudshell/main.js
@@ -261,14 +261,14 @@ window.addEventListener('startupFeatureStatus', async (e) => {
           }
         );
       }
-      // dotfilecontents.push(options.command);
+      dotfilecontents.push(options.command);
       return Promise.resolve();
     }, Promise.resolve());
     globalSettings.user = (await commandExecutor.execute('whoami', globalSettings.shellPrompt, { background: true, history: false })).trim();
     if (dotfilecontents.length > 0) {
       await commandExecutor.execute([
         'rm ${HOME}/.tweakit 2>/dev/null;',
-        'export DATETIME=$(date "+%Y-%m-%d %H:%M:%S");',
+        'export DATETIME=$(date "+%Y-%m-%dT%H:%M:%S");',
         `echo "# TweakIt for Azure Cloud Shell - Auto generated on \${DATETIME} by ${globalSettings.user}" > \${HOME}/.tweakit;`,
         ...dotfilecontents.join('\n').split('\n').map(line => `echo '${line.replace(/'/g, `'\\''`)}' >> \${HOME}/.tweakit;`),
         'grep -v \'source ${HOME}/.tweakit\' "${HOME}/.bashrc" > "${HOME}/.bashrc-${DATETIME}.bak";',
@@ -287,7 +287,7 @@ window.addEventListener('startupFeatureStatus', async (e) => {
         { background: true, history: false });
 
     // window.term.write(` Finished.${ASCII.ESC}[0m\r\n`);
-    window.term.write(globalSettings.shellPrompt);
+    // window.term.write(globalSettings.shellPrompt);
   }
   catch (err) {
     console.error('Error executing initial configuration:', err);


### PR DESCRIPTION
This pull request makes small adjustments to the Cloud Shell startup script handling. The changes ensure that user commands are properly appended to the dotfile and that the timestamp format in the generated `.tweakit` file matches the ISO 8601 standard. It also comments out a line that writes the shell prompt to the terminal at the end of the startup process.

- Dotfile command handling:
  * Ensures that `options.command` is pushed to `dotfilecontents`, so user commands are included in the generated `.tweakit` file.

- Timestamp formatting:
  * Changes the `DATETIME` variable in the shell script to use the ISO 8601 format (`YYYY-MM-DDTHH:MM:SS`) for improved consistency and readability.

- Terminal output:
  * Comments out the line that writes the shell prompt to the terminal after the startup configuration, likely to avoid duplicate prompts or unnecessary output.