### PR TITLE
fix: adjust cloud shell session handling in socket event handlers

### DIFF
--- a/content/js/cloudshell/main.js
+++ b/content/js/cloudshell/main.js
@@ -159,6 +159,8 @@ const socketOpenHandler = (e) => {
   );
 
   init();
+  keepCloudShellSession.stop();
+  globalSettings.tweakitOptions?.keepCloudShellSession?.status && keepCloudShellSession.start(socket);
 };
 
 const socketMessageHandler = (e) => {
@@ -312,6 +314,6 @@ window.addEventListener('updateFeatureStatus', async (e) => {
     }
   }
 
-  keepCloudShellSession.stop();
-  globalSettings.tweakitOptions?.keepCloudShellSession?.status && keepCloudShellSession.start(sockets.find(s => !s.url.endsWith('/control')));
+  // keepCloudShellSession.stop();
+  // globalSettings.tweakitOptions?.keepCloudShellSession?.status && keepCloudShellSession.start(sockets.find(s => !s.url.endsWith('/control')));
 });


### PR DESCRIPTION
This pull request updates how the `keepCloudShellSession` feature is managed in `content/js/cloudshell/main.js`. The main change is that the session keep-alive logic is now always restarted when the socket opens, and the logic in the `updateFeatureStatus` event handler has been commented out to prevent duplicate or conflicting session management.

Session management logic:

* The `keepCloudShellSession` is now always stopped and conditionally started in the `socketOpenHandler`, ensuring a clean and consistent session state when a new socket connection is established.
* The previous logic to stop and start `keepCloudShellSession` in the `updateFeatureStatus` event handler has been commented out, centralizing session management in the socket open handler and preventing redundant operations.