### PR TITLE
fix: enhance socket handling in KeepCloudShellSession

### DIFF
--- a/content/js/cloudshell/main.js
+++ b/content/js/cloudshell/main.js
@@ -17,6 +17,7 @@ class KeepCloudShellSession {
     }, this.pingTimeout);
   }
   start(socket) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return;
     this.socket = socket;
     this.socket.addEventListener('message', this.onMessageHandler.bind(this));
     this.socket.send(this.pingString);
@@ -25,6 +26,7 @@ class KeepCloudShellSession {
     this.timeout && clearTimeout(this.timeout);
     this.timeout = 0;
     this.socket && this.socket.removeEventListener('message', this.onMessageHandler.bind(this));
+    this.socket = null;
   }
 }
 
@@ -314,6 +316,6 @@ window.addEventListener('updateFeatureStatus', async (e) => {
     }
   }
 
-  // keepCloudShellSession.stop();
-  // globalSettings.tweakitOptions?.keepCloudShellSession?.status && keepCloudShellSession.start(sockets.find(s => !s.url.endsWith('/control')));
+  keepCloudShellSession.stop();
+  globalSettings.tweakitOptions?.keepCloudShellSession?.status && keepCloudShellSession.start(sockets.find(s => !s.url.endsWith('/control')));
 });


### PR DESCRIPTION
This pull request improves the stability and reliability of the `KeepCloudShellSession` feature in `content/js/cloudshell/main.js` by ensuring proper socket state checks and cleanup. The changes help prevent errors due to invalid WebSocket states and ensure that event listeners and socket references are correctly managed.

**Improvements to WebSocket session handling:**

* Added a check in the `start` method to ensure the socket exists and is open before proceeding, preventing attempts to use invalid sockets.
* In the `stop` method, set `this.socket` to `null` after removing the event listener to avoid retaining stale socket references.

**Feature status update handling:**

* Uncommented and enabled logic to stop and (conditionally) restart the `keepCloudShellSession` when the `updateFeatureStatus` event is triggered, ensuring the session state reflects the latest settings.