### PR TITLE
Bump to 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
+## [1.1.3](https://github.com/horihiro/TweakIt-for-Azure-ChromeExtension/releases/tag/1.1.3)
+### Bug Fix(es)
+  - Cloud Shell: remove redundant default startup command and ensure proper command formatting
+
 ## [1.1.2](https://github.com/horihiro/TweakIt-for-Azure-ChromeExtension/releases/tag/1.1.2)
 ### New feature(s)
   - Cloud Shell: support opening Cloud Shell in a new tab

--- a/content/js/cloudshell/main.js
+++ b/content/js/cloudshell/main.js
@@ -84,7 +84,6 @@ const commandExecutor = new CommandExecutor();
 const sockets = [];
 const defaultStartupCommands = [
   // Default startup commands
-  { command: { bash: 'export TWEAKIT_INJECTED=1', pwsh: '$Env:TWEAKIT_INJECTED=1' }, background: true, history: false },
   // { command: 'alias ll="ls -la"', background: true, history: false },
   // { command: `function tree() { cd $1 && pwd;find . | sort | sed '1d;s/^\\.//;s/\\/\\([^/]*\\)$/|--\\1/;s/\\/[^/|]*/|  /g' && cd - > /dev/null; }`, background: true, history: false },
 ];
@@ -274,13 +273,14 @@ window.addEventListener('startupFeatureStatus', async (e) => {
         'rm ${HOME}/.tweakit 2>/dev/null;',
         'export DATETIME=$(date "+%Y-%m-%dT%H:%M:%S");',
         `echo "# TweakIt for Azure Cloud Shell - Auto generated on \${DATETIME} by ${globalSettings.user}" > \${HOME}/.tweakit;`,
+        `echo "export TWEAKIT_INJECTED=1" >> \${HOME}/.tweakit;`,
         ...dotfilecontents.join('\n').split('\n').map(line => `echo '${line.replace(/'/g, `'\\''`)}' >> \${HOME}/.tweakit;`),
         'grep -v \'source ${HOME}/.tweakit\' "${HOME}/.bashrc" > "${HOME}/.bashrc-${DATETIME}.bak";',
         'cp ${HOME}/.bashrc-${DATETIME}.bak ${HOME}/.bashrc;',
         'unset DATETIME;',
         'echo "source ${HOME}/.tweakit" >>  ${HOME}/.bashrc;',
         'source ${HOME}/.tweakit;',
-        ...defaultStartupCommands.map(options => options.command[globalSettings.shellType] ).map(line => `${line.replace(/'/g, `'\\''`)}`),
+        ...defaultStartupCommands.map(options => options.command[globalSettings.shellType]).map(line => `${line.replace(/'/g, `'\\''`)};`),
       ].join(''), globalSettings.shellPrompt, { background: true, history: false });
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "TweakIt for Microsoft Azure Portal",
-  "version": "1.1.2",
-  "version_name": "1.1.2-ojisan",
+  "version": "1.1.3",
+  "version_name": "1.1.3- pike",
   "description": "Add features to Azure Portal",
   "permissions": [
     "storage",


### PR DESCRIPTION
This pull request addresses a bug in the Cloud Shell integration by removing a redundant default startup command and ensuring that startup commands are formatted correctly. It also updates the extension version to 1.1.3 and documents these changes in the changelog.

Bug fixes and improvements to Cloud Shell startup commands:

* Removed the redundant `export TWEAKIT_INJECTED=1` default startup command from the `defaultStartupCommands` array in `main.js`, as this is now handled elsewhere.
* Ensured that the `export TWEAKIT_INJECTED=1` command is properly appended to the `.tweakit` file during initialization, making the environment variable available as intended.
* Fixed formatting of startup commands by appending a semicolon to each command when constructing the startup script, ensuring proper command execution.

Versioning and documentation updates:

* Updated the extension version to `1.1.3` and changed the version name in `manifest.json`.
* Added a new entry to the `CHANGELOG.md` describing the bug fix for Cloud Shell startup commands.